### PR TITLE
feature(healthcheck): add expected HTTP response code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-config
+config.json5
 .env
+.idea

--- a/config.json5.example
+++ b/config.json5.example
@@ -13,7 +13,10 @@
   ],
   "targets": [
     {
-      "url": "http://www.example.com/"
+      "url": "http://www.example.com/",
+      "httpRequestConfig": {
+        "expectedResponseCode": 404
+      }
     },
     {
       "valueFrom": "env",

--- a/internal/healthcheck/target.go
+++ b/internal/healthcheck/target.go
@@ -1,6 +1,7 @@
 package healthcheck
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -43,6 +44,16 @@ func (t *Target) healthcheck() error {
 
 	if err != nil {
 		return errors.Wrapf(err, "%s Failed: %s", t.name(), t.Config.URL)
+	}
+
+	if resp.StatusCode != t.Config.HttpRequestConfig.ExpectedResponseCode {
+		return fmt.Errorf(
+			"%s Failed: %s.\nUnexpected HTTP response code %d, expecting %d.",
+			t.name(),
+			t.Config.URL,
+			resp.StatusCode,
+			t.Config.HttpRequestConfig.ExpectedResponseCode,
+		)
 	}
 
 	log.Printf("%s (%d): %s\n", t.name(), resp.StatusCode, t.Config.url())

--- a/internal/healthcheck/target_json.go
+++ b/internal/healthcheck/target_json.go
@@ -56,7 +56,8 @@ func (t *TargetJSON) url() string {
 func (t *TargetJSON) httpRequestConfig() *HttpRequestConfig {
 	if t.HttpRequestConfig == nil {
 		return &HttpRequestConfig{
-			Method: http.MethodGet,
+			Method:               http.MethodGet,
+			ExpectedResponseCode: http.StatusOK,
 		}
 	}
 

--- a/internal/healthcheck/target_json.go
+++ b/internal/healthcheck/target_json.go
@@ -15,9 +15,10 @@ type TargetJSON struct {
 }
 
 type HttpRequestConfig struct {
-	Method      string `json:"method"`
-	ContentType string `json:"contentType"`
-	Body        string `json:"body"`
+	Method               string `json:"method"`
+	ContentType          string `json:"contentType"`
+	Body                 string `json:"body"`
+	ExpectedResponseCode int    `json:"expectedResponseCode"`
 }
 
 func (t *TargetJSON) ToTarget() *Target {
@@ -57,6 +58,10 @@ func (t *TargetJSON) httpRequestConfig() *HttpRequestConfig {
 		return &HttpRequestConfig{
 			Method: http.MethodGet,
 		}
+	}
+
+	if t.HttpRequestConfig.ExpectedResponseCode == 0 {
+		t.HttpRequestConfig.ExpectedResponseCode = http.StatusOK
 	}
 
 	return t.HttpRequestConfig


### PR DESCRIPTION
### Issue:
There is no support if we want to ensure our target servers could be reached and returns the response code that we want (ie: `200 OK`).

### What this PR does:
* Add `expectedResponseCode` key to check whether the HTTP response code obtained from the target server is expected
* Default value of `expectedResponseCode` is `200`.
* Update `config.json5.example`

### How I Tested:
1. Create a webhook slack
2. Edit the `.env` and `.config.json5` with target server that returns 404

```bash
{
  "name": "Example",
  "alerts": [
    {
      type: "stdout",
    },
    {
      type: "slack-incoming-webhook",
      slackIncomingWebhookConfig: {
        url: "https://hooks.slack.com/services/",
      }
    },
  ],
  "targets": [
    {
      "url": "http://localhost:3000/",
      "httpRequestConfig": {
        "expectedResponseCode": 200
      }
    }
  ]
}

```

3. Check slack message
![image](https://user-images.githubusercontent.com/42166417/146755586-1fa3d4f7-3ef9-4f0a-b3c6-32125e995c8d.png)

